### PR TITLE
Simplify atom

### DIFF
--- a/Miku.cabal
+++ b/Miku.cabal
@@ -39,6 +39,7 @@ library
       LambdaCase
       RankNTypes
       NoImplicitPrelude
+      ImportQualifiedPost
   build-depends:
       base >=4.7 && <5
     , brick
@@ -66,6 +67,7 @@ executable miku
       LambdaCase
       RankNTypes
       NoImplicitPrelude
+      ImportQualifiedPost
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Miku
@@ -86,6 +88,7 @@ test-suite timeTracker-test
       LambdaCase
       RankNTypes
       NoImplicitPrelude
+      ImportQualifiedPost
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       Miku

--- a/dailyLog.md
+++ b/dailyLog.md
@@ -23,7 +23,7 @@
   Learning Type level programming in haskell.
   Reading book: Thinking with types.
 
-  **Tags:  Haskell, Miku**
+  **Tags:  Haskell, Learning**
 
 ---
 

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,7 @@ default-extensions:
 - LambdaCase
 - RankNTypes
 - NoImplicitPrelude
+- ImportQualifiedPost 
 
 library:
   source-dirs: src

--- a/src/Miku/Types/Log.hs
+++ b/src/Miku/Types/Log.hs
@@ -1,24 +1,25 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-{-# LANGUAGE DataKinds         #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE TypeApplications  #-}
-{-# LANGUAGE TypeFamilies      #-}
-{-# LANGUAGE TypeOperators     #-}
+{-# LANGUAGE DataKinds          #-}
+{-# LANGUAGE FlexibleInstances  #-}
+{-# LANGUAGE TypeApplications   #-}
+{-# LANGUAGE TypeFamilies       #-}
+{-# LANGUAGE TypeOperators      #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 module Miku.Types.Log
-  ( Heading(..),
-    HeadingFormat,
-    Task(..),
+  ( Task(..),
     TaskFormat,
+    Log (..),
     LogFormat,
-    Log (Log, logHeading, logTasks),
     readLog,
     writeLog
   )
 where
 
-import  Data.Text qualified as T
+import  Data.Text    qualified as T
+import  Data.Text.IO qualified as T
+import  Data.Coerce            (coerce)
 import  Data.Time              (Day)
 import  Text.Megaparsec        (runParser, parseTest)
 import  Text.Read              (read)
@@ -66,19 +67,28 @@ instance Atom HeadingFormat where
   showAtom (Heading day) = composeS @HeadingFormat @HeadingF mempty () day
 
 -----------------------------------------------------------------
--- | 'Task'
+-- | 'Name'
 -----------------------------------------------------------------
 
-data Task = Task
-  { taskName  :: Text,
-    taskStart :: Time,
-    taskEnd   :: Maybe Time,
-    taskDesc  :: Maybe Text,
-    taskTags  :: [Text]
-  }
-  deriving (Show)
+newtype Name = Name Text
+               deriving stock (Show, Eq)
 
-type TaskF = Text -> Time -> Maybe Time -> Maybe Text -> [Text] -> Task
+type NameFormat = (Prefix "###" :>> TakeTill "(" <: Token "(")
+type NameF      = () -> Text -> Name
+
+instance Atom NameFormat where
+  type AtomType NameFormat = Name
+  parseAtom = composeP @NameFormat @NameF (const $ Name . T.strip)
+  showAtom  = composeS @NameFormat @NameF mempty () . coerce
+  
+  
+-----------------------------------------------------------------
+-- | 'Description'
+-----------------------------------------------------------------
+
+newtype Description = Description Text
+                      deriving stock (Show, Eq)
+
 
 type DescLine = (Repeat 2 Space :> AlphaNum) :>> PrintChar <: Newline
 
@@ -87,27 +97,58 @@ instance Atom DescLine where
   parseAtom = composeP @DescLine (<>)
   showAtom  = composeS @DescLine @(Text -> Text -> Text) mempty mempty
 
-type Desc  =  Many DescLine :>> Repeat 1 Newline
+type DescriptionFormat  =  Many DescLine :>> Repeat 1 Newline
+type DescriptionF       =  [Text] -> () -> Description
 
-instance Atom Desc where
-  type AtomType Desc = Text
-  parseAtom = composeP @Desc (\a () -> T.unlines a)
-  showAtom  t = composeS @Desc @([Text] -> () -> Text) mempty (T.lines t)
+instance Atom DescriptionFormat where
+  type AtomType DescriptionFormat = Description
+  parseAtom = composeP @DescriptionFormat @DescriptionF (\a () -> Description $ T.unlines a)
+  showAtom  = composeS @DescriptionFormat @DescriptionF mempty . T.lines . coerce
+
+-----------------------------------------------------------------
+-- | 'Tags'
+-----------------------------------------------------------------
+
+newtype Tag = Tag Text
+              deriving stock (Show, Eq)
+
+type TagsFormat   = (Repeat 2 Space :> Literal "**" :> Prefix "Tags: ")
+                 :>> SepBy1 AlphaNum (Token "," <: Space <: Many Space)
+                 <: Literal "**" <: Repeat 2 Newline
+
+type TagF         = () -> [Text] -> [Tag]
+
+instance Atom TagsFormat where
+  type AtomType TagsFormat = [Tag]
+  parseAtom = composeP @TagsFormat @TagF (const $ map Tag)
+  showAtom  = composeS @TagsFormat @TagF  mempty () . coerce
+
+-----------------------------------------------------------------
+-- | 'Task'
+-----------------------------------------------------------------
+
+data Task = Task
+  { taskName  :: Name,
+    taskStart :: Time,
+    taskEnd   :: Maybe Time,
+    taskDesc  :: Maybe Description,
+    taskTags  :: [Tag]
+  }
+  deriving (Show)
+
+type TaskF = Name -> Time -> Maybe Time -> Maybe Description -> [Tag] -> Task
 
 type TaskSep = Many Newline :> Literal "---" <: Repeat 3 Newline <: Many Newline
 
-type Tags    = Repeat 2 Space :> Literal "**" :> Prefix "Tags: "
-            :> SepBy1 AlphaNum (Token "," <: Space <: Many Space)
-            <: Literal "**" <: Repeat 2 Newline
-
-type TaskFormat = (Prefix "###" :> TakeTill "(" <: Token "(")
+type TaskFormat = NameFormat
               :>> TimeFormat <: Space <: Token "-" <: Space
               :>> Optional TimeFormat <: Token ")" <: Repeat 2 Newline <: Many Newline
-              :>> Optional (Try Desc) :>> Tags <: TaskSep
+              :>> Optional (Try DescriptionFormat)
+              :>> TagsFormat <: TaskSep
 
 instance Atom TaskFormat where
   type AtomType TaskFormat = Task
-  parseAtom = composeP @TaskFormat @TaskF (Task . T.strip)
+  parseAtom = composeP @TaskFormat @TaskF Task
   showAtom (Task name start end desc tags) = composeS @TaskFormat @TaskF mempty name start end desc tags
 
 instance Element Task where
@@ -136,14 +177,14 @@ instance Element Log where
 
 readLog :: FilePath -> IO Log
 readLog f = do
-  input <- T.pack <$> readFile f
+  input <- T.readFile f
 
-  case runParser (parseAtom @LogFormat) "dailyLog.md" input of
+  case runParser parseElement "dailyLog.md" input of
     Left a    -> error $ T.pack $ show a
     Right log -> return log
 
-writeLog :: FilePath -> Log -> IO()
-writeLog f log = writeFile f $ T.unpack (showAtom @LogFormat log)
+writeLog :: FilePath -> Log -> IO ()
+writeLog f = T.writeFile f . showElement
 
 -- readLog :: FilePath -> IO ()
 -- readLog f = do

--- a/src/Miku/Types/Parser.hs
+++ b/src/Miku/Types/Parser.hs
@@ -13,6 +13,7 @@
 module Miku.Types.Parser
   ( Atom(..)
   , Composeable(..)
+  , Element(..)
   , type (:>>)
   , type (<:)
   , type (:>)
@@ -35,12 +36,13 @@ module Miku.Types.Parser
   )
   where
 
-import qualified Data.Text as T
-import           GHC.TypeLits
-import           Text.Megaparsec hiding (Token, many, some)
-import           Text.Megaparsec.Char
-import           Text.Read (read)
-import           Relude hiding (natVal, Alt)
+import  Data.Text       qualified as T
+import  GHC.TypeLits
+import  Text.Megaparsec           hiding (Token, many, some)
+import  Text.Megaparsec.Char
+import  Text.Read                        (read)
+
+import  Relude                    hiding (natVal, Alt)
 
 
 class Composeable (a :: Type) (f :: Type) where
@@ -54,7 +56,16 @@ class Atom (a :: Type) where
   type AtomType a :: Type
 
   parseAtom :: Parser (AtomType a)
-  showAtom :: AtomType a -> Text
+  showAtom  :: AtomType a -> Text
+
+class Element (a :: Type) where
+  type ElementFormat a :: Type
+  
+  showElement :: (Atom (ElementFormat a), AtomType (ElementFormat a) ~ a) => a -> Text
+  showElement = showAtom @(ElementFormat a)
+  
+  parseElement :: (Atom (ElementFormat a), AtomType (ElementFormat a) ~ a) => Parser a
+  parseElement = parseAtom @(ElementFormat a)
 
 
 data (p :: k1) :> (a :: k2)

--- a/src/Miku/Types/Time.hs
+++ b/src/Miku/Types/Time.hs
@@ -7,11 +7,11 @@
 {-# LANGUAGE TypeOperators     #-}
 
 module Miku.Types.Time
-  ( Time,
-    TimeP ,
-    time,
-    timeHrs,
-    timeMins,
+  ( Time
+  , TimeFormat
+  , time
+  , timeHrs
+  , timeMins
   )
 where
 
@@ -24,16 +24,19 @@ data Time = Time
   }
   deriving (Show)
 
-type TimeP = Digits <: Literal "h" <: Token ":" :>> Digits <: Literal "m"
+type TimeFormat = Digits <: Literal "h" <: Token ":" :>> Digits <: Literal "m"
 type TimeF = Integer -> Integer -> Time
 
 time :: TimeF
 time h m = Time (h + div m 60) (mod m 60)
 
-instance Atom TimeP where
-  type AtomType TimeP = Time
-  parseAtom                 = composeP @TimeP time
-  showAtom (Time hrs mins)  = composeS @TimeP @TimeF "" hrs mins
+instance Atom TimeFormat where
+  type AtomType TimeFormat = Time
+  parseAtom                 = composeP @TimeFormat time
+  showAtom (Time hrs mins)  = composeS @TimeFormat @TimeF "" hrs mins
+
+instance Element Time where
+  type ElementFormat Time = TimeFormat
 
 instance Eq Time where
   (Time h1 m1) == (Time h2 m2) = h1 == h2 && m1 == m2


### PR DESCRIPTION
introduce `Element` typeclass, now we don't need to use functions like `showAtom` and `parseAtom` . This removes the need to use type applications as GHC can infer types of functions like `showElement` and `parseElement` automatically.

This is also kinda related to #4.